### PR TITLE
Set saving_pathname to the current working directory if left blank

### DIFF
--- a/src/AlphaPickle.py
+++ b/src/AlphaPickle.py
@@ -29,7 +29,7 @@ from matplotlib import pyplot as plt ,colors as cols ,cm as cm
 import json
 from sys import exit
 from Bio import PDB as pdb
-
+import os
 
 # Define class for AlphaFold metadata file and class methods
 class AlphaFoldMetaData(object):
@@ -39,6 +39,8 @@ class AlphaFoldMetaData(object):
         self.FastaSequence = FastaSequence
         self.saving_filename = self.PathToFile.split("/")[-1].split(".")[0]
         self.saving_pathname = self.PathToFile.split(self.saving_filename)[0]
+        if self.saving_pathname == "":
+            self.saving_pathname = os.getcwd()
         if ranking:
             self.saving_filename = "ranked_{}".format(ranking)
 


### PR DESCRIPTION
When the full file path is not provided alphapickle currently tries to write to the root directory `/`. This would be better if it defaulted to `/path/to/current/directory`.

A test for a blank file path has been added and then sets the saving_pathname to the current working directory if it is blank.